### PR TITLE
Fix typos

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Event', link: '/event' },
-      { text: 'Paticipate', link: '/participate' },
+      { text: 'Participate', link: '/participate' },
       { text: 'About', link: '/about' },
     ],
 

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -28,7 +28,7 @@
  *   custom containers.
  *
  * - `default`: The color used purely for subtle indication without any
- *   special meanings attched to it such as bg color for menu hover state.
+ *   special meanings attached to it such as bg color for menu hover state.
  *
  * - `brand`: Used for primary brand colors, such as link text, button with
  *   brand theme, etc.


### PR DESCRIPTION
從範本產生的 `theme.css` 裡面的註解和 `.vitepress/config.ts` 有錯字。