### PR TITLE
Fix type-checking by explicitly specifying `include` in tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepare": "husky",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "type-check": "vue-tsc --noEmit"
+    "type-check": "vue-tsc"
   },
   "dependencies": {
     "vue": "^3.4.37"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,10 @@
     "noEmit": true,
     "isolatedModules": true,
     "skipLibCheck": true
-  }
+  },
+  "include": [
+    ".vitepress/**/*",
+    "components/**/*",
+    "loaders/**/*"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // Required until this issue is resolved
     // https://github.com/microsoft/TypeScript/issues/52460
     "paths": {
-      "#*": ["./src/*"]
+      "#*": ["./*"]
     },
 
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
這個 PR 修好了 `type-check` 腳本因為沒有包含 `.vitepress` 目錄的關係，找不到任何可以檢查的檔案而失敗。

此外，`tsconfig.json` 的 `path` 設定和 `package.json` 的不符，這樣會讓編輯器建議不正確的匯入路徑，我也順便修好了。

由於在 `tsconfig.json` 中已經設定 `noEmit`，所以 `type-check` 時不需要再指定 `--noEmit`。