### PR TITLE
Enable Emmet in Markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lerna-debug.log*
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .fleet
 .idea
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,9 +58,16 @@
   // Use the workspace version of TypeScript
   "typescript.tsdk": "node_modules/typescript/lib",
 
-  // Enable Vue language server for markdown
+  // Enable Vue language server for Markdown
   "vue.server.includeLanguages": [
     "vue",
     "markdown"
-  ]
+  ],
+
+  // Enable Emmet for Markdown
+  "emmet.excludeLanguages": [],
+  "emmet.includeLanguages": {
+    "markdown": "html"
+  },
+  "emmet.triggerExpansionOnTab": true
 }


### PR DESCRIPTION
這個 PR 會讓 VS Code 在 Markdown 檔案中啟用 [Emmet](https://emmet.io/) 自動完成（就像在 HTML 那樣），並且在按下 `tab` 鍵時展開。對於時常需要在 Markdown 中使用 Vue 元件和 HTML 元素的我們來說非常實用。