### PR TITLE
Add local iconset sourced from `assets/icons`

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitepress'
 import Components from 'unplugin-vue-components/vite'
 import Icons from 'unplugin-icons/vite'
 import IconsResolver from 'unplugin-icons/resolver'
+import { FileSystemIconLoader } from 'unplugin-icons/loaders'
 
 // Subpath imports (e.g. '#data') for TypeScript files are not supported
 // See https://github.com/vuejs/vitepress/issues/4173
@@ -16,10 +17,18 @@ export default defineConfig({
         dirs: ['../components'],
         include: [/\.vue($|\?)/, /\.md($|\?)/],
         resolvers: [
-          IconsResolver({ prefix: 'icon' }),
+          IconsResolver({
+            prefix: 'icon',
+            customCollections: ['local'],
+          }),
         ],
       }),
-      Icons({ compiler: 'vue3' }),
+      Icons({
+        compiler: 'vue3',
+        customCollections: {
+          local: FileSystemIconLoader('assets/icons'),
+        },
+      }),
     ],
   },
   title: conference.title,


### PR DESCRIPTION
這則 PR 設定了 `unplugin-icons` 和 `unplugin-vue-components`，讓我們能在 `assets/icons` 加入自訂圖示 SVG 並在 Vue/Markdown 中使用。

使用範例：建立 `assets/icons/coscop.svg`，在 `content/index.md` 中就能用 `<IconLocalCoscup />` 顯示這個圖示。