### PR TITLE
Simplify Overpass API loader for readibility

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,6 @@ export default antfu(
       'node/prefer-global/process': ['error', 'always'],
       'style/arrow-parens': ['error', 'always'],
       'style/brace-style': ['error', '1tbs'],
-      'style/no-multi-spaces': ['error', { ignoreEOLComments: true }],
       'style/operator-linebreak': ['error', 'after', { overrides: { '?': 'before', ':': 'before' } }],
       'vue/max-attributes-per-line': ['error'],
       'vue/attributes-order': ['error', { alphabetical: true }],

--- a/loaders/overpass.data.ts
+++ b/loaders/overpass.data.ts
@@ -8,21 +8,12 @@ import { defineLoader } from 'vitepress'
  * @example const geometry = await queryOverpass(['way(1159328965)'])
  */
 function queryOverpass(objects: string[]): Promise<GeoJSON.GeoJsonObject> {
-  /* eslint-disable prefer-template --
-   * string concatenation is more readable across multiple lines
-   */
-  // Build the Overpass API query
-  const query =
-    '[out:json];' +         // Set the output format to JSON
-    objects.map((object) => // For each object
-      `${object};` +        // Query the object
-      'out geom;',          // Output the geometry
-    ).join('')              // Join the queries
-  /* eslint-enable prefer-template */
+  // Query the objects' geometries
+  const queries = objects.map((object) => `${object};out geom;`)
 
   return fetch('https://overpass-api.de/api/interpreter', {
     method: 'POST',
-    body: `data=${query}`,
+    body: `data=[out:json];${queries.join('')}`,
   })
     .then((response) => response.json())
     .then(osmToGeoJSON)
@@ -36,8 +27,7 @@ interface OverpassData {
 /**
  * The geometry of the venue and its buildings.
  */
-declare const data: OverpassData
-export { data }
+export declare const data: OverpassData
 
 export default defineLoader({
   async load(): Promise<OverpassData> {


### PR DESCRIPTION
這個 PR 重新整理了 #19 中引入的 Overpass API loader，透過簡化代碼結構讓其更易於理解。

此外，這個 PR 也恢復了 `style/no-multi-spaces` ESLint 規則的原設定，因為專案已經沒有設定它的需要，而且修改這項設定可能會導致過於寬鬆的排版規則。

雖然這項 PR 不影響 loader 的行為，不過我在本地開發 `/event` 時會遇到 fetch 逾時 (`ETIMEDOUT`)，再麻煩大家確認能不能成功載入。
Edit: CI 能編譯，所以應該是我自己的網路問題。