### PR TITLE
Replace outdated Corepack binary with official pnpm setup action

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -11,10 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          run_install: false
 
-      - name: Setup Node.js environment
+      - name: Install Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
           node-version-file: package.json


### PR DESCRIPTION
Corepack recently updated its registry keys and shipped the changes in v3.1.0. However, the version of Corepack bundled with Node.js 20 has not been updated, causing CI failures when attempting to install pnpm via Corepack.

This PR resolves the issue by using `pnpm/action-setup` instead of relying on `corepack enable` to install the package manager.

[Related issue from `actions/setup-node`](https://redirect.github.com/actions/setup-node/issues/1222)